### PR TITLE
Revert "Avoids unnecessary diffs when the vgw_telemetry is changed outside the terraform workflow"

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.1
+current_version = 3.1.2
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [3.1.2](https://github.com/plus3it/terraform-aws-tardigrade-vpn-connection/releases/tag/3.1.2)
+
+**Released**: 2024.02.16
+
+**Summary**:
+
+*   Reverts change using ignore_changes on the vgw_telemetry attribute. Since that
+    attribute is "computed", Terraform already ignores changes on it. The original
+    problem with the diff must be related to a different configuration specific
+    to the user config.
+
 ### [3.1.1](https://github.com/plus3it/terraform-aws-tardigrade-vpn-connection/releases/tag/3.1.1)
 
 **Released**: 2024.01.12

--- a/main.tf
+++ b/main.tf
@@ -89,16 +89,6 @@ resource "aws_vpn_connection" "this" {
       "Name" = var.vpn_connection.name
     },
   )
-
-  lifecycle {
-    ignore_changes = [
-      # vgw_telemetry is a wholly-calculated attribute with no input arguments.
-      # It may be modified outside of the terraform lifecycle by changes to the
-      # tunnel. Ignore changes to avoid unnecessary diffs that are not caused by
-      # changes to inputs.
-      vgw_telemetry,
-    ]
-  }
 }
 
 resource "aws_customer_gateway" "this" {


### PR DESCRIPTION
This reverts commit ddfdefb.

Terraform warns about exactly this change, trying to ignore changes
on a computed value. Apparently, this is not the cause of the persistent
diff, as originally thought. Instead, what I believe is happening,
is that when the user *outputs* the entire vpn_connection object,
it is the *output* that is changing. The user can address this by
updating the output so it does not include the "last_status_change"
attribute. There may be a better way of doing this, but this is what
I came up with in a pinch:

    value = merge(
      { for key, value in module.vpn_connection.vpn_connection : key => value if key != "vgw_telemetry" },
      { vgw_telemetry = toset([
        for item in module.vpn_connection.vpn_connection.vgw_telemetry : { for key, value in item : key => value if key != "last_status_change" }
      ]) },
    )